### PR TITLE
Configure animation options using the class name

### DIFF
--- a/scroll.js
+++ b/scroll.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", function() {
   "use strict"
 
-  var links = document.querySelectorAll("a.scroll")
+  var links = document.querySelectorAll('a[class^="scroll"]')
   var i = links.length
   var root = /firefox|trident/i.test(navigator.userAgent) ? document.documentElement : document.body
   var easeInOutCubic = function(t, b, c, d) {
@@ -16,11 +16,13 @@ document.addEventListener("DOMContentLoaded", function() {
       var endPos = document.getElementById(/[^#]+$/.exec(this.href)[0]).getBoundingClientRect().top
       var maxScroll = root.scrollHeight - window.innerHeight
       var scrollEndValue = startPos + endPos < maxScroll ? endPos : maxScroll - startPos
-      var duration = 900
+      var options = /-(\d+)(-(\w+))?/.exec(this.className);
+      var duration = options ? Number(options[1]) : 900;
+      var easing = options && eval(options[3]) ? options[3] : "easeInOutCubic";
       var scroll = function(timestamp) {
         startTime = startTime || timestamp
         var elapsed = timestamp - startTime
-        var progress = easeInOutCubic(elapsed, startPos, scrollEndValue, duration)
+        var progress = eval(easing)(elapsed, startPos, scrollEndValue, duration)
         root.scrollTop = progress
         elapsed < duration && requestAnimationFrame(scroll)
       }   


### PR DESCRIPTION
This would let users specify the animation's duration and easing method using variants of the class name.
A link classed "scroll" would scroll to the relevant anchor in 900ms using the default easeInOutCubic.
A link classed "scroll-1500" would scroll in 1500ms, etc.
A link classed "scroll-1200-bounce" would scroll in 1200ms, using a function named "bounce" as the easing function, just define it somewhere, eg:

var bounce = function (t, b, c, d) {
    if ((t/=d) < (1/2.75)) {
      return c*(7.5625*t*t) + b;
    } else if (t < (2/2.75)) {
      return c*(7.5625*(t-=(1.5/2.75))*t + .75) + b;
    } else if (t < (2.5/2.75)) {
      return c*(7.5625*(t-=(2.25/2.75))*t + .9375) + b;
    } else {
      return c*(7.5625*(t-=(2.625/2.75))*t + .984375) + b;
    }
  }

Not sure about this last option. Should the easing functions be pre-defined, should we use the standard names or shortcuts for convenience, does it make sense to let anyone create custom easing functions, etc... Anyway,this was just a quick idea.